### PR TITLE
return from http to https and change refresh token for email sending

### DIFF
--- a/src/controllers/auth_controller.js
+++ b/src/controllers/auth_controller.js
@@ -5,7 +5,7 @@ const { BadRequestError, UnauthenticatedError } = require('../errors');
 const jwt = require('jsonwebtoken');
 const createTransporter = require('../mailerConfig');
 const getHtmlTemplate = require('../helpers/getHtmlTemplate');
-const URL_TO_RESET = 'https://localhost:3005/reset-password/';
+const URL_TO_RESET = 'http://localhost:3005/reset-password/';
 
 const register = async (req, res) => {
   const { username, email, password } = req.body;


### PR DESCRIPTION
## One Line Description
Change from using HTTPS to HTTP. Update the refresh token in the env file.
## Requirements
Ensure that you have a refresh token stored in your .env file. 
Check the dd-team1-release-updates group on Slack for the latest refreshed token.

